### PR TITLE
only append visible svg items in modal for perf, #8

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -60,6 +60,7 @@
 	float: right;
 }
 .acf-icon-picker__popup ul{
+  position: relative;
 	margin: 0;
 }
 .acf-icon-picker__popup ul:before,
@@ -70,6 +71,7 @@
 }
 
 .acf-icon-picker__popup ul li{
+  position: absolute;
 	width: 25%;
 	float: left;
 	padding: 10px;


### PR DESCRIPTION
This is a first approach of how to handle a lot of svg items.

Items are absolutely positioned and only visible items are appended to the dom. Once an item become invisible it is added to a recycled_items array and reused later. With this solution there is roughly less than 50 `<li>` items in the `<ul>`, no matter how much icons are available.

Without this change, opening the modal when there was 10'000 icons was making the browser nearly unresponsive (> 10 seconds), and searching was nearly impossible. With this first patch, opening, searching and scrolling feel instantaneous.