### PR TITLE
trigger a change when icon is removed

### DIFF
--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -189,6 +189,8 @@
         .find('.acf-icon-picker__svg')
         .html('<span class="acf-icon-picker__svg--span">+</span>');
 
+      jQuery('.acf-icon-picker__img input').trigger('change');
+
       parent
         .find('.acf-icon-picker__remove')
         .removeClass('acf-icon-picker__remove--active');


### PR DESCRIPTION
this is quivalent to changing the icon on line 19.
Without it, when using the field in a gutenberg block,
just removing the icon is not reflected in the block preview and
does not get saved when saving the post containing the block.