### PR TITLE
Added support for Internet Explorer 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ add_filter('acf_icon_url',
 
 ## Changelog
 
+* 1.10.0 - Fix Internet Explorer 11 compatibility issues
 * 1.9.0 - Fix issue with Gutenberg preview not updating when removing. Thanks to [cherbst](https://github.com/houke/acf-icon-picker/pull/23)
 * 1.8.0 - Fix issue with Gutenberg not saving icon. Thanks to [tlewap](https://github.com/houke/acf-icon-picker/pull/17)
 * 1.7.0 - 2 new filters for more control over icon path. Thanks to [benjibee](https://github.com/houke/acf-icon-picker/pull/11)

--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -1,9 +1,9 @@
 <?php
 /*
 Plugin Name: Advanced Custom Fields: Icon Picker
-Plugin URI: https://github.com/houke/acf-icon-picker
+Plugin URI: https://github.com/ajreading/acf-icon-picker
 Description: Allows you to pick an icon from a predefined list
-Version: 1.9.0
+Version: 1.10.0
 Author: Houke de Kwant
 Author URI: ttps://github.com/houke/
 License: GPLv2 or later
@@ -21,7 +21,7 @@ class acf_plugin_icon_picker {
 	function __construct() {
 
 		$this->settings = array(
-			'version'	=> '1.9.0',
+			'version'	=> '1.10.0',
 			'url'		=> plugin_dir_url( __FILE__ ),
 			'path'		=> plugin_dir_path( __FILE__ )
 		);

--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -1,11 +1,11 @@
 <?php
 /*
-Plugin Name: Advanced Custom Fields: Icon Picker
+Plugin Name: Advanced Custom Fields: Icon Picker (AJReading fork)
 Plugin URI: https://github.com/ajreading/acf-icon-picker
 Description: Allows you to pick an icon from a predefined list
 Version: 1.10.0
 Author: Houke de Kwant
-Author URI: ttps://github.com/houke/
+Author URI: https://github.com/houke/
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 GitHub Plugin URI: https://github.com/houke/acf-icon-picker

--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -17,7 +17,7 @@
     jQuery('.acf-icon-picker__popup-holder').trigger('close');
     jQuery('.acf-icon-picker__popup-holder').remove();
     jQuery('.acf-icon-picker__img input').trigger('change');
-    
+
     active_item
       .parents('.acf-icon-picker')
       .find('.acf-icon-picker__remove')
@@ -33,19 +33,19 @@
       if (iv.svgs.length == 0) {
         var list = '<p>' + iv.no_icons_msg + '</p>';
       } else {
-        var list = `<ul id="icons-list">`;
-        list += `</ul>`;
+        var list = '<ul id="icons-list">';
+        list += '</ul>';
       }
 
       jQuery('body').append(
-        `<div class="acf-icon-picker__popup-holder">
-        <div class="acf-icon-picker__popup">
-        <a class="acf-icon-picker__popup__close" href="javascript:">close</a>
-        <h4 class="acf-icon-picker__popup__title">ACF Icon Picker - Choose icon</h4>
-        <input class="acf-icon-picker__filter" type="text" id="filterIcons" placeholder="Start typing to filter icons" />
-          ${list}
-        </div>
-      </div>`
+        '<div class="acf-icon-picker__popup-holder">' +
+        '<div class="acf-icon-picker__popup">' +
+        '<a class="acf-icon-picker__popup__close" href="javascript:">close</a>' +
+        '<h4 class="acf-icon-picker__popup__title">ACF Icon Picker - Choose icon</h4>' +
+        '<input class="acf-icon-picker__filter" type="text" id="filterIcons" placeholder="Start typing to filter icons" />' +
+        list +
+        '</div>' +
+        '</div>'
       );
 
       jQuery('.acf-icon-picker__popup-holder').on('close', function() {
@@ -106,7 +106,7 @@
           var x = i % columns * item_width;
 
           // If we already have the element visible we can continue
-          var $el = $(`[data-acf-icon-index="${i}"][data-svg="${svg.name}"]`);
+          var $el = $('[data-acf-icon-index="' + i + '"][data-svg="' + svg.name + '"]');
           // If item already exist we can skip.
           if ($el.length) continue;
 
@@ -116,12 +116,14 @@
           }
           else {
             // Or create a new element.
-            $el = $(`<li>
-              <div class="acf-icon-picker__popup-svg">
-                <img src="" alt=""/>
-              </div>
-              <span class="icons-list__name"></span>
-            </li>`);
+            $el = $(
+              '<li>' +
+                '<div class="acf-icon-picker__popup-svg">' +
+                  '<img src="" alt=""/>' +
+                '</div>' +
+                '<span class="icons-list__name"></span>' +
+              '</li>'
+            );
           }
 
           // We use attr instead of data since we want to use css selector.
@@ -129,13 +131,13 @@
             'data-svg': svg.name,
             'data-acf-icon-index': i
           }).css({
-            transform: `translate(${x}px, ${y}px)`
+            transform: 'translate(' + x + 'px, ' + y + 'px)'
           });
           $el.find('.icons-list__name').text(svg['name'].replace(
             /[-_]/g,
             ' '
           ));
-          $el.find('img').attr('src', `${iv.path}${svg['icon']}`);
+          $el.find('img').attr('src', iv.path + svg['icon']);
           $list.append($el);
         }
 
@@ -149,7 +151,7 @@
       const iconsFilter = document.querySelector('#filterIcons');
 
       function filterIcons(wordToMatch) {
-        return iv.svgs.filter(icon => {
+        return iv.svgs.filter(function (icon) {
           var name = icon.name.replace(/[-_]/g, ' ');
           const regex = new RegExp(wordToMatch, 'gi');
           return name.match(regex);
@@ -189,9 +191,9 @@
         .find('.acf-icon-picker__svg')
         .html('<span class="acf-icon-picker__svg--span">+</span>');
 
-      jQuery('.acf-icon-picker__img input').trigger('change');
+        jQuery('.acf-icon-picker__img input').trigger('change');
 
-      parent
+        parent
         .find('.acf-icon-picker__remove')
         .removeClass('acf-icon-picker__remove--active');
     });


### PR DESCRIPTION
Internet Explorer 11 support can be added easily by removing the use of template literals and error function expressions. Whilst WordPress still officially supports IE11, it's useful to also support it.