### PR TITLE
Fix deprecated warning issue (2)

### DIFF
--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -18,6 +18,8 @@ if( !class_exists('acf_plugin_icon_picker') ) :
 
 class acf_plugin_icon_picker {
 
+	public $settings;
+	
 	function __construct() {
 
 		$this->settings = array(


### PR DESCRIPTION
Deprecated: Creation of dynamic property acf_plugin_icon_picker::$settings is deprecated in acf-icon-picker.php on line 25