### PR TITLE
change way for retrieving the filename

### DIFF
--- a/fields/acf-icon-picker-v5.php
+++ b/fields/acf-icon-picker-v5.php
@@ -42,9 +42,9 @@ class acf_field_icon_picker extends acf_field {
 		$files = array_diff(scandir($this->path), array('.', '..'));
 		foreach ($files as $file) {
 			if( pathinfo($file, PATHINFO_EXTENSION) == 'svg' ){
-				$exploded = explode('.', $file);
+				$filename = pathinfo($file, PATHINFO_FILENAME);
 				$icon = array(
-					'name' => $exploded[0],
+					'name' => $filename,
 					'icon' => $file
 				);
 				array_push($this->svgs, $icon);


### PR DESCRIPTION
I had troubles for retrieving the filename if the assets got compiled and have an additional unique string (e.g. `documentation-icon.6fbb6c.svg`). 
`eplode()` and `$exploded[0]` will only save `documentation-icon` instead of `documentation-icon.6fbb6c` in this case.

`pathinfo($file, PATHINFO_FILENAME)` should fix this problem.