### PR TITLE
feat: Fix compat with ACF 6.3

### DIFF
--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -10,34 +10,37 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 GitHub Plugin URI: https://github.com/houke/acf-icon-picker
 GitHub Branch: master
-*/
+ */
 
-if( ! defined( 'ABSPATH' ) ) exit;
-
-if( !class_exists('acf_plugin_icon_picker') ) :
-
-class acf_plugin_icon_picker {
-
-	public $settings = array();
-	
-	function __construct() {
-
-		$this->settings = array(
-			'version'	=> '1.9.1',
-			'url'		=> plugin_dir_url( __FILE__ ),
-			'path'		=> plugin_dir_path( __FILE__ )
-		);
-
-		add_action('acf/include_field_types', 	array($this, 'include_field_types'));
-
-	}
-
-	function include_field_types( $version = false ) {
-		include_once('fields/acf-icon-picker-v5.php');
-	}
-
+if (!defined('ABSPATH')) {
+	exit;
 }
 
-new acf_plugin_icon_picker();
+if (!class_exists('acf_plugin_icon_picker')) :
+
+	class acf_plugin_icon_picker
+	{
+
+		public $settings = array();
+
+		public function __construct()
+		{
+
+			$this->settings = array(
+				'version' => '1.9.1',
+				'url'     => plugin_dir_url(__FILE__),
+				'path'    => plugin_dir_path(__FILE__),
+			);
+
+			add_action('acf/include_field_types', array($this, 'include_field_types'));
+		}
+
+		public function include_field_types($version = false)
+		{
+			include_once 'fields/acf-icon-picker-v5.php';
+		}
+	}
+
+	new acf_plugin_icon_picker();
 
 endif;

--- a/fields/acf-icon-picker-v5.php
+++ b/fields/acf-icon-picker-v5.php
@@ -1,141 +1,142 @@
 <?php
 
-if( ! defined( 'ABSPATH' ) ) exit;
+if (!defined('ABSPATH')) {
+	exit;
+}
 
-if( !class_exists('acf_field_icon_picker') ) :
+if (!class_exists('acf_field_icon_picker')) :
 
-class acf_field_icon_picker extends acf_field {
+	class acf_field_custom_icon_picker extends acf_field
+	{
 
-	/**
-	 * Stores the settings for the field
-	 *
-	 * @var array
-	 */
-	private array $settings = array();
+		/**
+		 * Stores the settings for the field
+		 *
+		 * @var array
+		 */
+		private array $settings = array();
 
-	/**
-	 * Stores the path suffix to the icons
-	 *
-	 * @var string
-	 */
-	private string $path_suffix;
+		/**
+		 * Stores the path suffix to the icons
+		 *
+		 * @var string
+		 */
+		private string $path_suffix;
 
-	/**
-	 * Stores the path to the icons
-	 *
-	 * @var string
-	 */
-	private string $path;
+		/**
+		 * Stores the path to the icons
+		 *
+		 * @var string
+		 */
+		private string $path;
 
-	/**
-	 * Stores the url to the icons
-	 *
-	 * @var string
-	 */
-	private string $url;
+		/**
+		 * Stores the url to the icons
+		 *
+		 * @var string
+		 */
+		private string $url;
 
-	/**
-	 * Stores the icons
-	 *
-	 * @var array
-	 */
-	private array $svgs = array();
+		/**
+		 * Stores the icons
+		 *
+		 * @var array
+		 */
+		private array $svgs = array();
 
+		public function __construct($settings)
+		{
 
-	function __construct( $settings ) {
+			$this->name = 'icon-picker';
 
-		$this->name = 'icon-picker';
+			$this->label = __('Icon Picker (custom)', 'acf-icon-picker');
 
-		$this->label = __('Icon Picker', 'acf-icon-picker');
+			$this->category = 'advanced';
 
-		$this->category = 'jquery';
+			$this->defaults = array(
+				'initial_value' => '',
+			);
 
-		$this->defaults = array(
-			'initial_value'	=> '',
-		);
+			$this->l10n = array(
+				'error' => __('Error!', 'acf-icon-picker'),
+			);
 
-		$this->l10n = array(
-			'error'	=> __('Error!', 'acf-icon-picker'),
-		);
+			$this->settings      = $settings;
+			$this->path_suffix   = apply_filters('acf_icon_path_suffix', 'assets/img/acf/');
+			$this->path          = apply_filters('acf_icon_path', $this->settings['path']) . $this->path_suffix;
+			$this->url           = apply_filters('acf_icon_url', $this->settings['url']) . $this->path_suffix;
+			$priority_dir_lookup = get_stylesheet_directory() . '/' . $this->path_suffix;
 
-		$this->settings = $settings;
-
-		$this->path_suffix = apply_filters( 'acf_icon_path_suffix', 'assets/img/acf/' );
-
-		$this->path = apply_filters( 'acf_icon_path', $this->settings['path'] ) . $this->path_suffix;
-
-		$this->url = apply_filters( 'acf_icon_url', $this->settings['url'] ) . $this->path_suffix;
-
-		$priority_dir_lookup = get_stylesheet_directory() . '/' . $this->path_suffix;
-
-		if ( file_exists( $priority_dir_lookup ) ) {
-			$this->path = $priority_dir_lookup;
-			$this->url = get_stylesheet_directory_uri() . '/' . $this->path_suffix;
-		}
-
-		$files = array_diff(scandir($this->path), array('.', '..'));
-		foreach ($files as $file) {
-			if( pathinfo($file, PATHINFO_EXTENSION) == 'svg' ){
-				$exploded = explode('.', $file);
-				$icon = array(
-					'name' => $exploded[0],
-					'icon' => $file
-				);
-				array_push($this->svgs, $icon);
+			if (file_exists($priority_dir_lookup)) {
+				$this->path = $priority_dir_lookup;
+				$this->url  = get_stylesheet_directory_uri() . '/' . $this->path_suffix;
 			}
+
+			$files = array_diff(scandir($this->path), array('.', '..'));
+			foreach ($files as $file) {
+				if (pathinfo($file, PATHINFO_EXTENSION) == 'svg') {
+					$exploded = explode('.', $file);
+					$icon     = array(
+						'name' => $exploded[0],
+						'icon' => $file,
+					);
+					array_push($this->svgs, $icon);
+				}
+			}
+
+			parent::__construct();
 		}
 
-    	parent::__construct();
-	}
-
-	function render_field( $field ) {
-		$input_icon = $field['value'] != "" ? $field['value'] : $field['initial_value'];
-		$svg = $this->path . $input_icon . '.svg';
-		?>
+		public function render_field($field)
+		{
+			$input_icon = "" != $field['value'] ? $field['value'] : $field['initial_value'];
+			$svg        = $this->path . $input_icon . '.svg';
+?>
 			<div class="acf-icon-picker">
 				<div class="acf-icon-picker__img">
 					<?php
-						if ( file_exists( $svg ) ) {
-							$svg = $this->url . $input_icon . '.svg';
-							echo '<div class="acf-icon-picker__svg">';
-						   	echo '<img src="'.$svg.'" alt=""/>';
-						    echo '</div>';
-						}else{
-							echo '<div class="acf-icon-picker__svg">';
-							echo '<span class="acf-icon-picker__svg--span">&plus;</span>';
-						    echo '</div>';
-						}
+					if (file_exists($svg)) {
+						$svg = $this->url . $input_icon . '.svg';
+						echo '<div class="acf-icon-picker__svg">';
+						echo '<img src="' . $svg . '" alt=""/>';
+						echo '</div>';
+					} else {
+						echo '<div class="acf-icon-picker__svg">';
+						echo '<span class="acf-icon-picker__svg--span">&plus;</span>';
+						echo '</div>';
+					}
 					?>
-					<input type="hidden" readonly name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($input_icon) ?>"/>
+					<input type="hidden" readonly name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($input_icon) ?>" />
 				</div>
-				<?php if ( $field['required' ] == false ) { ?>
+				<?php if (false == $field['required']) { ?>
 					<span class="acf-icon-picker__remove">
 						Remove
 					</span>
 				<?php } ?>
 			</div>
-		<?php
+<?php
+		}
+
+		public function input_admin_enqueue_scripts()
+		{
+
+			$url     = $this->settings['url'];
+			$version = $this->settings['version'];
+
+			wp_register_script('acf-input-icon-picker', "{$url}assets/js/input.js", array('acf-input'), $version);
+			wp_enqueue_script('acf-input-icon-picker');
+
+			wp_localize_script('acf-input-icon-picker', 'iv', array(
+				'path'         => $this->url,
+				'svgs'         => $this->svgs,
+				'no_icons_msg' => sprintf(esc_html__('To add icons, add your svg files in the /%s folder in your theme.', 'acf-icon-picker'), $this->path_suffix),
+			));
+
+			wp_register_style('acf-input-icon-picker', "{$url}assets/css/input.css", array('acf-input'), $version);
+			wp_enqueue_style('acf-input-icon-picker');
+		}
 	}
-
-	function input_admin_enqueue_scripts() {
-
-		$url = $this->settings['url'];
-		$version = $this->settings['version'];
-
-		wp_register_script( 'acf-input-icon-picker', "{$url}assets/js/input.js", array('acf-input'), $version );
-		wp_enqueue_script('acf-input-icon-picker');
-
-		wp_localize_script( 'acf-input-icon-picker', 'iv', array(
-			'path' => $this->url,
-			'svgs' => $this->svgs,
-			'no_icons_msg' => sprintf( esc_html__('To add icons, add your svg files in the /%s folder in your theme.', 'acf-icon-picker'), $this->path_suffix)
-		) );
-
-		wp_register_style( 'acf-input-icon-picker', "{$url}assets/css/input.css", array('acf-input'), $version );
-		wp_enqueue_style('acf-input-icon-picker');
-	}
-}
-new acf_field_icon_picker( $this->settings );
+	new acf_field_custom_icon_picker($this->settings);
 
 endif;
 

--- a/fields/acf-icon-picker-v5.php
+++ b/fields/acf-icon-picker-v5.php
@@ -6,6 +6,42 @@ if( !class_exists('acf_field_icon_picker') ) :
 
 class acf_field_icon_picker extends acf_field {
 
+	/**
+	 * Stores the settings for the field
+	 *
+	 * @var array
+	 */
+	private array $settings = array();
+
+	/**
+	 * Stores the path suffix to the icons
+	 *
+	 * @var string
+	 */
+	private string $path_suffix;
+
+	/**
+	 * Stores the path to the icons
+	 *
+	 * @var string
+	 */
+	private string $path;
+
+	/**
+	 * Stores the url to the icons
+	 *
+	 * @var string
+	 */
+	private string $url;
+
+	/**
+	 * Stores the icons
+	 *
+	 * @var array
+	 */
+	private array $svgs = array();
+
+
 	function __construct( $settings ) {
 
 		$this->name = 'icon-picker';
@@ -36,8 +72,6 @@ class acf_field_icon_picker extends acf_field {
 			$this->path = $priority_dir_lookup;
 			$this->url = get_stylesheet_directory_uri() . '/' . $this->path_suffix;
 		}
-
-		$this->svgs = array();
 
 		$files = array_diff(scandir($this->path), array('.', '..'));
 		foreach ($files as $file) {


### PR DESCRIPTION
Hi @houke ,

Thanks for your work on this plugin! This PR creates the properties in advance to prevent dynamic creation of properties warnings in PHP 8.2 and above. I do have some other ideas as well for this plugin to further modernize the codebase if you're open to that.

Looking forward to your reply!

**Update 31-05**

Advanced custom fields 6.3 is now available and introduces it's own [icon picker](https://www.advancedcustomfields.com/blog/acf-6-3-0-released/#new-field-type).

The class `acf_field_icon_picker` used in the plugin interfered with the new ACF field that has exactly the same classname.
My new set of changes do the following:

- Rename the field label to **Icon field (custom)** to differentiate between the two fields.
- move the field to the new category `advanced` since `jquery` is no longer an existing category
- Renamed the class from `acf_field_icon_picker` to `acf_field_custom_icon_picker` so it does not longer interfere

After this the plugin loads again as needed. I would really like to have an update for this since this breaks quite a lot of websites I run. I am open for any suggestions you have!