### PR TITLE
Acf 6.3 compatibility: Change class name to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Add the svg icons you want to be available in your theme to an acf folder inside
 
 This ACF field type is compatible with:
 
-- [x] ACF 6
-- [x] ACF 5
+-   [x] ACF 6
+-   [x] ACF 5
 
 ## Screenshots
 
@@ -26,11 +26,13 @@ This ACF field type is compatible with:
 ## Installation
 
 ### via Composer
+
 1. Add a line to your repositories array: `{ "type": "git", "url": "https://github.com/houke/acf-icon-picker" }`
 2. Add a line to your require block: `"houke/acf-icon-picker": "dev-master"`
 3. Run: `composer update`
 
 ### Manually
+
 1. Copy the `acf-icon-picker` folder into your `wp-content/plugins` folder
 2. Activate the Icon Selector plugin via the plugins admin page
 3. Create a new field via ACF and select the Icon Selector type
@@ -89,14 +91,15 @@ add_filter('acf_icon_url',
 
 ## Changelog
 
-* 1.9.1 - ACF 6 compatibility fix. Thanks to [idflood](https://github.com/houke/acf-icon-picker/pull/30)
-* 1.9.0 - Fix issue with Gutenberg preview not updating when removing. Thanks to [cherbst](https://github.com/houke/acf-icon-picker/pull/23)
-* 1.8.0 - Fix issue with Gutenberg not saving icon. Thanks to [tlewap](https://github.com/houke/acf-icon-picker/pull/17)
-* 1.7.0 - 2 new filters for more control over icon path. Thanks to [benjibee](https://github.com/houke/acf-icon-picker/pull/11)
-* 1.6.0 - Performance fix with lots of icons. Thanks to [idflood](https://github.com/houke/acf-icon-picker/pull/9)
-* 1.5.0 - Fix issue where searching for icons would break preview if icon name has space
-* 1.4.0 - Add filter to change folder where svg icons are stored
-* 1.3.0 - Adding close option on modal
-* 1.2.0 - Adding search filter input to filter through icons by name
-* 1.1.0 - Add button to remove the selected icon when the field is not required
-* 1.0.0 - First release
+-   1.9.2 - ACF 6.3 compatibility fix. Change class name to avoid conflict with new ACF field type.
+-   1.9.1 - ACF 6 compatibility fix. Thanks to [idflood](https://github.com/houke/acf-icon-picker/pull/30)
+-   1.9.0 - Fix issue with Gutenberg preview not updating when removing. Thanks to [cherbst](https://github.com/houke/acf-icon-picker/pull/23)
+-   1.8.0 - Fix issue with Gutenberg not saving icon. Thanks to [tlewap](https://github.com/houke/acf-icon-picker/pull/17)
+-   1.7.0 - 2 new filters for more control over icon path. Thanks to [benjibee](https://github.com/houke/acf-icon-picker/pull/11)
+-   1.6.0 - Performance fix with lots of icons. Thanks to [idflood](https://github.com/houke/acf-icon-picker/pull/9)
+-   1.5.0 - Fix issue where searching for icons would break preview if icon name has space
+-   1.4.0 - Add filter to change folder where svg icons are stored
+-   1.3.0 - Adding close option on modal
+-   1.2.0 - Adding search filter input to filter through icons by name
+-   1.1.0 - Add button to remove the selected icon when the field is not required
+-   1.0.0 - First release

--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -3,7 +3,7 @@
 Plugin Name: Advanced Custom Fields: Icon Picker
 Plugin URI: https://github.com/houke/acf-icon-picker
 Description: Allows you to pick an icon from a predefined list
-Version: 1.9.1
+Version: 1.9.2
 Author: Houke de Kwant
 Author URI: https://github.com/houke/
 License: GPLv2 or later

--- a/fields/acf-icon-picker-v5.php
+++ b/fields/acf-icon-picker-v5.php
@@ -2,9 +2,9 @@
 
 if( ! defined( 'ABSPATH' ) ) exit;
 
-if( !class_exists('acf_field_icon_picker') ) :
+if( !class_exists('acf_field_icon_picker_plugin') ) :
 
-class acf_field_icon_picker extends acf_field {
+class acf_field_icon_picker_plugin extends acf_field {
 
 	function __construct( $settings ) {
 
@@ -101,7 +101,7 @@ class acf_field_icon_picker extends acf_field {
 		wp_enqueue_style('acf-input-icon-picker');
 	}
 }
-new acf_field_icon_picker( $this->settings );
+new acf_field_icon_picker_plugin( $this->settings );
 
 endif;
 


### PR DESCRIPTION
Hi @houke ,

I made a small update just to change the class name to avoid conflict with ACF's new icon picker field type in their version 6.3.